### PR TITLE
small update so that it's easy to call the test twice

### DIFF
--- a/JSONSpeed/ViewController.swift
+++ b/JSONSpeed/ViewController.swift
@@ -31,52 +31,144 @@ class ViewController: UIViewController {
         }
         do {
             let dict = try NSJSONSerialization.JSONObjectWithData(data!, options: NSJSONReadingOptions.AllowFragments)
-            print(dict)
             return dict as? NSDictionary
         } catch {}
         return nil
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+
+    override func viewDidAppear(animated: Bool) {
+        super.viewDidAppear(animated)
+
+        print("\n\n----- Dummy initial tests ---\n\n\n")
+        tailorTest()
+        unboxTest()
+        objectMapperTest()
+        argoTest()
+        evReflectionTest()
+
+        print("\n\n----- Start actual test ---\n\n\n")
+
+        tailorTest()
+        tailorTest()
+
+        unboxTest()
+        unboxTest()
+
+        objectMapperTest()
+        objectMapperTest()
+
+        argoTest()
+        argoTest()
 
         evReflectionTest()
         evReflectionTest()
-
-//        let speed = Mapper<SpeedObjectMapper>().map(dict)!
-//        let speed = SpeedObjectMapper(JSON: dict as! [String: AnyObject])!
-
-//        let speed: SpeedUnbox? = Unbox(dict as! [String: AnyObject])!
-
-//        let dict2 = dict as? [String: AnyObject]
-//        let speed = SpeedTailor(dict)
-
-//        let speed: SpeedArgo? = decode(dict!)
-
-
-//        print(speed!.list.first!.name, speed!.name)
-//        print(speed) // CAN ADD TIME TO PARSE TIME...
-
-
 
     }
 
+    func argoTest() {
+        // Prepare for test
+        guard let data: NSData = readFile("speed") else {
+            print("COULD NOT READ FILE")
+            return
+        }
+
+        print("SpeedArgo: START PARSE")
+        let start = NSDate()
+
+        // Test this
+        let dict = fileToDict(data)
+        let speed: SpeedArgo = decode(dict!)!
+
+        // Show results
+        print(speed.list.first!.name, speed.name)
+        print("SpeedArgo: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
+    }
+
+    func tailorTest() {
+        // Prepare for test
+        guard let data: NSData = readFile("speed") else {
+            print("COULD NOT READ FILE")
+            return
+        }
+
+        print("Tailor: START PARSE")
+        let start = NSDate()
+
+        // Test this
+        let dict = fileToDict(data) as! [String : AnyObject]
+        let speed = SpeedTailor(dict)
+
+        // Show results
+        print("CRASH!?")
+        //print(speed.list!.first!.name, speed.name)
+        //print("Tailor: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
+    }
+
+    func unboxTest() {
+        // Prepare for test
+        guard let data: NSData = readFile("speed") else {
+            print("COULD NOT READ FILE")
+            return
+        }
+
+        print("UNBOX: START PARSE")
+        let start = NSDate()
+
+        // Test this
+        if let dict = fileToDict(data) as? UnboxableDictionary {
+            do {
+                let speed: SpeedUnbox = try Unbox(dict)
+
+                // Show results
+                print(speed.list!.first!.name, speed.name)
+                print("UNBOX: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
+            } catch _ {
+                print("COULD NOT UNBOX")
+            }
+        } else {
+            print("DICTIONARY IS NOT UNBOXABLE")
+        }
+    }
+
+    func objectMapperTest() {
+        // Prepare for test
+        guard let data: NSData = readFile("speed") else {
+            print("COULD NOT READ FILE")
+            return
+        }
+
+        print("OBJECTMAPPER2: START PARSE")
+        let start = NSDate()
+
+        // Test this
+        let dict = fileToDict(data)
+        let speed = SpeedObjectMapper(JSON: dict as! [String: AnyObject])!
+
+        // Show results
+        print(speed.list!.first!.name, speed.name)
+        print("OBJECTMAPPER2: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
+    }
+
+
     func evReflectionTest() {
+        // Prepare for test
         guard let data: NSData = readFile("speed") else {
             print("COULD NOT READ FILE")
             return
         }
         let json = String(data: data, encoding: NSUTF8StringEncoding)
 
-        print("EVReflection: START PARSE")
+        print("EVREFLECTION: START PARSE")
         let start = NSDate()
 
+        // Test this
         let speed = SpeedReflection(json: json)
 
+        // Show results
         print(speed.list!.first!.name, speed.name)
-        print("EVReflection: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
+        print("EVREFLECTION: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
     }
-
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()

--- a/JSONSpeed/ViewController.swift
+++ b/JSONSpeed/ViewController.swift
@@ -11,54 +11,73 @@ import Unbox
 import ObjectMapper
 import Argo
 import Curry
-
+import EVReflection
 
 class ViewController: UIViewController {
 
-    static func readFile(name: String) -> NSDictionary? {
+
+    func readFile(name: String) -> NSData? {
         print("readFile")
         let bundle = NSBundle.mainBundle()
-        let path = bundle.pathForResource(name, ofType: "json")
-        let data = NSData(contentsOfFile: path!)
+        if let path = bundle.pathForResource(name, ofType: "json") {
+            return NSData(contentsOfFile: path)
+        }
+        return nil
+    }
+
+    func fileToDict(data: NSData?)  -> NSDictionary? {
+        if data == nil {
+            return nil
+        }
         do {
             let dict = try NSJSONSerialization.JSONObjectWithData(data!, options: NSJSONReadingOptions.AllowFragments)
             print(dict)
             return dict as? NSDictionary
-        }catch {}
+        } catch {}
         return nil
     }
-    
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view, typically from a nib.
-        
-        print("START")
-        let start = NSDate()
-        let dict = ViewController.readFile("speed")
-        
-        
-        let speed = SpeedReflection(dictionary: dict!)
-        
+
+        evReflectionTest()
+        evReflectionTest()
+
 //        let speed = Mapper<SpeedObjectMapper>().map(dict)!
 //        let speed = SpeedObjectMapper(JSON: dict as! [String: AnyObject])!
-        
+
 //        let speed: SpeedUnbox? = Unbox(dict as! [String: AnyObject])!
-        
+
 //        let dict2 = dict as? [String: AnyObject]
 //        let speed = SpeedTailor(dict)
-        
+
 //        let speed: SpeedArgo? = decode(dict!)
-        
-        
+
+
 //        print(speed!.list.first!.name, speed!.name)
-        print(speed.list!.first!.name, speed.name)
 //        print(speed) // CAN ADD TIME TO PARSE TIME...
-        
-        print("FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
-        
+
+
+
     }
-    
+
+    func evReflectionTest() {
+        guard let data: NSData = readFile("speed") else {
+            print("COULD NOT READ FILE")
+            return
+        }
+        let json = String(data: data, encoding: NSUTF8StringEncoding)
+
+        print("EVReflection: START PARSE")
+        let start = NSDate()
+
+        let speed = SpeedReflection(json: json)
+
+        print(speed.list!.first!.name, speed.name)
+        print("EVReflection: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
+    }
+
+
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
@@ -66,4 +85,3 @@ class ViewController: UIViewController {
 
 
 }
-

--- a/JSONSpeed/ViewController.swift
+++ b/JSONSpeed/ViewController.swift
@@ -36,6 +36,20 @@ class ViewController: UIViewController {
         return nil
     }
 
+    func doTest(type: String, test: (data: NSData) -> ()) {
+        // Prepare for test
+        guard let data: NSData = readFile("speed") else {
+            print("ERROR: COULD NOT READ FILE")
+            return
+        }
+
+        print("\(type): start parse")
+        let start = NSDate()
+
+        test(data: data)
+
+        print("\(type): finish parse in seconds \(NSDate().timeIntervalSinceDate(start))")
+    }
 
     override func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
@@ -67,113 +81,52 @@ class ViewController: UIViewController {
     }
 
     func argoTest() {
-        // Prepare for test
-        guard let data: NSData = readFile("speed") else {
-            print("COULD NOT READ FILE")
-            return
+        doTest("SpeedArgo") { data in
+            let dict = self.fileToDict(data)
+            let speed: SpeedArgo = decode(dict!)!
+            print(speed.list.first!.name, speed.name)
         }
-
-        print("SpeedArgo: START PARSE")
-        let start = NSDate()
-
-        // Test this
-        let dict = fileToDict(data)
-        let speed: SpeedArgo = decode(dict!)!
-
-        // Show results
-        print(speed.list.first!.name, speed.name)
-        print("SpeedArgo: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
     }
 
-    func tailorTest() {
-        // Prepare for test
-        guard let data: NSData = readFile("speed") else {
-            print("COULD NOT READ FILE")
-            return
+
+    func objectMapperTest() {
+        doTest("ObjectMapper") { data in
+            let dict = self.fileToDict(data)
+            let speed = SpeedObjectMapper(JSON: dict as! [String: AnyObject])!
+            print(speed.list!.first!.name, speed.name)
         }
+    }
 
-        print("Tailor: START PARSE")
-        let start = NSDate()
-
-        // Test this
-        let dict = fileToDict(data) as! [String : AnyObject]
-        let speed = SpeedTailor(dict)
-
-        // Show results
-        print("CRASH!?")
-        //print(speed.list!.first!.name, speed.name)
-        //print("Tailor: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
+    func evReflectionTest() {
+        doTest("EVReflection") { data in
+            let json = String(data: data, encoding: NSUTF8StringEncoding)
+            let speed = SpeedReflection(json: json)
+            print(speed.list!.first!.name, speed.name)
+        }
     }
 
     func unboxTest() {
-        // Prepare for test
-        guard let data: NSData = readFile("speed") else {
-            print("COULD NOT READ FILE")
-            return
-        }
-
-        print("UNBOX: START PARSE")
-        let start = NSDate()
-
-        // Test this
-        if let dict = fileToDict(data) as? UnboxableDictionary {
-            do {
-                let speed: SpeedUnbox = try Unbox(dict)
-
-                // Show results
-                print(speed.list!.first!.name, speed.name)
-                print("UNBOX: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
-            } catch _ {
-                print("COULD NOT UNBOX")
+        doTest("Unbox") { data in
+            if let dict = self.fileToDict(data) as? UnboxableDictionary {
+                do {
+                    let speed: SpeedUnbox = try Unbox(dict)
+                    print(speed.list!.first!.name, speed.name)
+                } catch _ {
+                    print("ERROR: COULD NOT UNBOX")
+                }
+            } else {
+                print("ERROR: DICTIONARY IS NOT UNBOXABLE")
             }
-        } else {
-            print("DICTIONARY IS NOT UNBOXABLE")
         }
     }
 
-    func objectMapperTest() {
-        // Prepare for test
-        guard let data: NSData = readFile("speed") else {
-            print("COULD NOT READ FILE")
-            return
+    func tailorTest() {
+        doTest("EVReflection") { data in
+            let dict = self.fileToDict(data) as! [String : AnyObject]
+            let speed = SpeedTailor(dict)
+            print("CRASH!?")
+            //print(speed.list!.first!.name, speed.name)
         }
-
-        print("OBJECTMAPPER2: START PARSE")
-        let start = NSDate()
-
-        // Test this
-        let dict = fileToDict(data)
-        let speed = SpeedObjectMapper(JSON: dict as! [String: AnyObject])!
-
-        // Show results
-        print(speed.list!.first!.name, speed.name)
-        print("OBJECTMAPPER2: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
     }
-
-
-    func evReflectionTest() {
-        // Prepare for test
-        guard let data: NSData = readFile("speed") else {
-            print("COULD NOT READ FILE")
-            return
-        }
-        let json = String(data: data, encoding: NSUTF8StringEncoding)
-
-        print("EVREFLECTION: START PARSE")
-        let start = NSDate()
-
-        // Test this
-        let speed = SpeedReflection(json: json)
-
-        // Show results
-        print(speed.list!.first!.name, speed.name)
-        print("EVREFLECTION: FINISH PARSE IN SECONDS \(NSDate().timeIntervalSinceDate(start))")
-    }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        // Dispose of any resources that can be recreated.
-    }
-
 
 }


### PR DESCRIPTION
The result with the EVReflection 2.29.0 version on an iPhone 6S is:

readFile
Tailor: START PARSE
CRASH!?
readFile
Tailor: START PARSE
CRASH!?
readFile
UNBOX: START PARSE
Optional("String Long Name") Optional("String Long Name")
UNBOX: FINISH PARSE IN SECONDS 0.00763100385665894
readFile
UNBOX: START PARSE
Optional("String Long Name") Optional("String Long Name")
UNBOX: FINISH PARSE IN SECONDS 0.00822603702545166
readFile
OBJECTMAPPER2: START PARSE
Optional("String Long Name") Optional("String Long Name")
OBJECTMAPPER2: FINISH PARSE IN SECONDS 0.00934898853302002
readFile
OBJECTMAPPER2: START PARSE
Optional("String Long Name") Optional("String Long Name")
OBJECTMAPPER2: FINISH PARSE IN SECONDS 0.0093960165977478
readFile
SpeedArgo: START PARSE
String Long Name String Long Name
SpeedArgo: FINISH PARSE IN SECONDS 0.0174559950828552
readFile
SpeedArgo: START PARSE
String Long Name String Long Name
SpeedArgo: FINISH PARSE IN SECONDS 0.016789972782135
readFile
EVREFLECTION: START PARSE
Optional("String Long Name") Optional("String Long Name")
EVREFLECTION: FINISH PARSE IN SECONDS 0.0772730112075806
readFile
EVREFLECTION: START PARSE
Optional("String Long Name") Optional("String Long Name")
EVREFLECTION: FINISH PARSE IN SECONDS 0.0772199630737305
